### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/JonathanWoollett-Light/cargo-maintained/compare/v0.2.0...v0.2.1) - 2025-07-10
+
+### Other
+
+- Adds commitlint configuration
+- Adds commit message linting workflow
+- Updates convco-action to v0.2.0
+- Adds conventional commits check workflow
+- Adds release-plz workflow
+- Update Cargo.toml
+- Update main.rs
+- Update main.rs
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-maintained"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ansi_term",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-maintained"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A tool to check crates are up to date."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `cargo-maintained`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/JonathanWoollett-Light/cargo-maintained/compare/v0.2.0...v0.2.1) - 2025-07-10

### Other

- Adds commitlint configuration
- Adds commit message linting workflow
- Updates convco-action to v0.2.0
- Adds conventional commits check workflow
- Adds release-plz workflow
- Update Cargo.toml
- Update main.rs
- Update main.rs
- Update README.md
- Update README.md
- Update README.md
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).