### PR TITLE
docs: Removes unused documentation link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ keywords = [
 ]
 
 repository = "https://github.com/JonathanWoollett-Light/cargo-maintained"
-documentation = "https://docs.rs/cargo-maintained/"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
Removes the `documentation` field from `Cargo.toml` as it was uneeded as the package is a binary.