### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/JonathanWoollett-Light/cargo-maintained/compare/v0.2.1...v0.3.0) - 2025-07-12
+
+### Added
+
+- [**breaking**] complete rework
+
+### Fixed
+
+- tests and docs
+
+### Other
+
+- reduce test output
+- create dependabot.yml
+- dependabot
+- add CI workflow for Rust projects
+- fix clippy
+- disable stdout/stderr inheritance in tests
+- remove unused documentation link
+
 ## [0.2.1](https://github.com/JonathanWoollett-Light/cargo-maintained/compare/v0.2.0...v0.2.1) - 2025-07-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-maintained"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-maintained"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "A tool to check crates are up to date."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `cargo-maintained`: 0.2.1 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/JonathanWoollett-Light/cargo-maintained/compare/v0.2.1...v0.3.0) - 2025-07-12

### Added

- [**breaking**] complete rework

### Fixed

- tests and docs

### Other

- reduce test output
- create dependabot.yml
- dependabot
- add CI workflow for Rust projects
- fix clippy
- disable stdout/stderr inheritance in tests
- remove unused documentation link
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).